### PR TITLE
WIP: add request throttling logic

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.19'
+        go-version: '1.20'
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.16'
+        go-version: '1.19'
 
     - name: Test
       run: go test -v ./...

--- a/counter.go
+++ b/counter.go
@@ -1,0 +1,54 @@
+package retryhttp
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type atomicCounter struct {
+	entries   []uint64
+	currEntry atomic.Int32
+}
+
+func newAtomicCounter(stop <-chan bool, numEntries int, timeSpan time.Duration) *atomicCounter {
+	c := atomicCounter{
+		entries: make([]uint64, numEntries),
+	}
+
+	// move buckets on a timer
+	t := time.NewTicker(timeSpan / time.Duration(numEntries))
+	go func() {
+		for {
+			select {
+			case <-stop:
+				// the ticker cannot be gc'd until Stop is called
+				t.Stop()
+				return
+			case <-t.C:
+				// calculate next index
+				next := (c.currEntry.Load() + 1) % int32(numEntries)
+
+				// clear the next bucket
+				atomic.StoreUint64(&c.entries[next], 0)
+
+				// update current index to next
+				c.currEntry.Store(next)
+			}
+		}
+	}()
+
+	return &c
+}
+
+func (c *atomicCounter) increment() {
+	atomic.AddUint64(&c.entries[c.currEntry.Load()], 1)
+}
+
+func (c *atomicCounter) read() uint64 {
+	var sum uint64
+	for _, entry := range c.entries {
+		sum += entry
+	}
+
+	return sum
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/justinrixx/retryhttp
 
-go 1.19
+go 1.20

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/justinrixx/retryhttp
 
-go 1.16
+go 1.19

--- a/options.go
+++ b/options.go
@@ -75,6 +75,18 @@ func WithAttemptTimeout(attemptTimeout time.Duration) func(*Transport) {
 	}
 }
 
+// WithThrottler configures a throttler to be used for requests. No throttler
+// is used by default. Note that using the provided [DefaultThrottler] requires
+// additional memory and CPU to keep track of state for throttling decisions.
+// Also note that if using any throttler, provided by this package or custom,
+// [ErrThrottled] is used to signal that a request was throttled. This can result
+// in a non-nil error ([ErrThrottled]) with a non-nil http response.
+func WithThrottler(throttler Throttler) func(*Transport) {
+	return func(t *Transport) {
+		t.throttler = throttler
+	}
+}
+
 // SetMaxRetries can be used to override the settings on a Transport.
 // Any request made with the returned context will have its MaxRetries setting
 // overridden with the provided value.

--- a/throttler.go
+++ b/throttler.go
@@ -9,18 +9,50 @@ import (
 	"time"
 )
 
+type (
+	// Throttler is an interface which decides if a retry should be throttled. This is
+	// useful for easing the pressure on an overloaded dependency, allowing it to more
+	// effectively make progress and recover.
+	//
+	// In order for most throttlers to make valid decisions, some amount of data must
+	// be recorded about previous requests and their results. For example, the throttler
+	// provided by [NewDefaultThrottler] tracks the total number of requests made, the
+	// number of requests which received an indicator of overload, and the total number
+	// of retries made. These counts are maintained across a 2 minute sliding window.
+	// RecordStats is called each time a response is received, but before consulting
+	// the [ShouldRetryFn] or [Throttler.ShouldThrottle] (and either performing another
+	// attempt or returning the response as-is).
+	//
+	// ShouldThrottle is called before each attempt. Note that this is per attempt, not
+	// per retry, which means the initial (non-retry) request has the potential to be
+	// throttled. Throttlers can use the [Attempt.Count] to determine if an attempt is
+	// a retry or the initial request if they choose to. Note that [Attempt.Count] begins
+	// at zero.
+	Throttler interface {
+		// ShouldThrottle decides whether a request should be throttled before it is
+		// made. It is called before each attempt (including the initial one).
+		ShouldThrottle(attempt Attempt) bool
+
+		// RecordStats is an opportunity for the throttler to record information about
+		// requests made and their responses to use for future decisions. ShouldThrottle
+		// is inadequate because the response to the call to ShouldThrottle for the
+		// initial request is unknown at the time it is called.
+		RecordStats(attempt Attempt)
+	}
+)
+
+// noopthrottler records no stats and never throttles
+type noopThrottler struct{}
+
+func (*noopThrottler) ShouldThrottle(_ Attempt) bool {
+	return false
+}
+
+func (*noopThrottler) RecordStats(_ Attempt) {}
+
 const (
 	defaultTimespanSeconds = 120                         // 2 mins
 	defaultBuckets         = defaultTimespanSeconds / 10 // 10s per bucket
-)
-
-type (
-	// Throttler is an interface decides if a retry should be throttled
-	Throttler interface {
-		ShouldThrottle(attempt Attempt) bool
-		RecordStats(attempt Attempt)
-		Stop()
-	}
 )
 
 type defaultThrottler struct {
@@ -37,11 +69,17 @@ type defaultThrottler struct {
 
 // NewDefaultThrottler constructs a new parameterized throttler. k is described in
 // [this equation].
+//
 // retryBudget is the per-client retry budget described in the "Deciding to Retry"
 // section of the same chapter.
 //
+// The default throttler makes no attempt to segment requests into different
+// dependencies, so it is recommended that one [Transport] be used per dependency.
+//
+// To avoid leaking memory and compute resources, be sure to call Stop on teardown.
+//
 // [this equation]: https://sre.google/sre-book/handling-overload/#eq2101
-func NewDefaultThrottler(k float64, retryBudget float64) defaultThrottler {
+func NewDefaultThrottler(k float64, retryBudget float64) Throttler {
 	totalStop := make(chan bool)
 	overloadStop := make(chan bool)
 	retriedStop := make(chan bool)
@@ -50,7 +88,7 @@ func NewDefaultThrottler(k float64, retryBudget float64) defaultThrottler {
 	overloadCounter := newAtomicCounter(overloadStop, defaultBuckets, time.Second*defaultTimespanSeconds)
 	retriedCounter := newAtomicCounter(retriedStop, defaultBuckets, time.Second*defaultTimespanSeconds)
 
-	return defaultThrottler{
+	return &defaultThrottler{
 		totalReqs:      totalCounter,
 		overloadedReqs: overloadCounter,
 		retriedReqs:    retriedCounter,

--- a/throttler.go
+++ b/throttler.go
@@ -1,0 +1,109 @@
+package retryhttp
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultTimespanSeconds = 120                         // 2 mins
+	defaultBuckets         = defaultTimespanSeconds / 10 // 10s per bucket
+)
+
+var ErrThrottled = errors.New("retry throttled")
+
+// Throttler is an interface decides if a retry should be throttled
+type Throttler interface {
+	ShouldThrottle(res *http.Response, err error) bool
+	Stop()
+}
+
+type defaultThrottler struct {
+	totalReqs      *atomicCounter
+	overloadedReqs *atomicCounter
+	retriedReqs    *atomicCounter
+	k              float64
+	retryBudget    float64
+
+	totalStop    chan<- bool
+	overloadStop chan<- bool
+	retriedStop  chan<- bool
+}
+
+// NewDefaultThrottler constructs a new parameterized throttler. k is described in
+// [this equation].
+// retryBudget is the per-client retry budget described in the "Deciding to Retry"
+// section of the same chapter.
+//
+// [this equation]: https://sre.google/sre-book/handling-overload/#eq2101
+func NewDefaultThrottler(k float64, retryBudget float64) defaultThrottler {
+	totalStop := make(chan bool)
+	overloadStop := make(chan bool)
+	retriedStop := make(chan bool)
+
+	totalCounter := newAtomicCounter(totalStop, defaultBuckets, time.Second*defaultTimespanSeconds)
+	overloadCounter := newAtomicCounter(overloadStop, defaultBuckets, time.Second*defaultTimespanSeconds)
+	retriedCounter := newAtomicCounter(retriedStop, defaultBuckets, time.Second*defaultTimespanSeconds)
+
+	return defaultThrottler{
+		totalReqs:      totalCounter,
+		overloadedReqs: overloadCounter,
+		retriedReqs:    retriedCounter,
+		k:              k,
+		retryBudget:    retryBudget,
+	}
+}
+
+// ShouldThrottle decides whether a request should be throttled.
+func (t defaultThrottler) ShouldThrottle(res *http.Response, err error, isRetry bool) bool {
+	t.recordStats(res, err, isRetry)
+
+	total := t.totalReqs.read()
+	fTotal := float64(total)
+
+	if isRetry {
+		// check per-client retry budget
+		retried := t.retriedReqs.read()
+		if float64(retried)/fTotal > t.retryBudget {
+			return false
+		}
+	}
+
+	// https://sre.google/sre-book/handling-overload/#eq2101
+	overloaded := t.overloadedReqs.read()
+	fAccepts := float64(total - overloaded)
+	p := math.Max(0, (fTotal-(t.k*fAccepts))/(fTotal+1))
+
+	return p > rand.Float64()
+}
+
+// recordStats records information about a request which the throttler can use later
+// to make throttling decisions. This throttler records 429s and context deadline
+// exceeded errors as signal of overload.
+func (t defaultThrottler) recordStats(res *http.Response, err error, isRetry bool) {
+	t.totalReqs.increment()
+	if isRetry {
+		t.retriedReqs.increment()
+	}
+
+	if (err != nil && errors.Is(err, context.DeadlineExceeded)) ||
+		(res != nil && res.StatusCode == http.StatusTooManyRequests) {
+		t.overloadedReqs.increment()
+	}
+}
+
+func (t defaultThrottler) Stop() {
+	go func() {
+		t.totalStop <- true
+	}()
+	go func() {
+		t.overloadStop <- true
+	}()
+	go func() {
+		t.retriedStop <- true
+	}()
+}


### PR DESCRIPTION
I have been reading the Google SRE book and found [this chapter on handling server overload](https://sre.google/sre-book/handling-overload/) very interesting. The whole chapter is worth a read, but the summary is:

- A server entering overload is not good. It often creates a feedback loop where falling behind on requests leads to queuing them in memory, which creates memory pressure, which results in more GC runs, which reduces the amount of cpu resources for actually serving requests, which leads to falling further behind on requests.
- Because of this, getting a server to recover from overload requires reducing the proportional load significantly (e.g. if running at 110% of its maximum reqs/sec caused the system to enter overload, it may require traffic to be as low as 20-30% to fully recover).
- A caller retrying during overload can greatly exacerbate the feedback loop and delay recovery.

The book outlines several overload mitigations in place at Google. Some of these require tighter integration with different parts of the system (standardized request headers, resource utilization reporting, etc), but there are 2 which are relevant to this package and can be implemented without controlling more of the stack:

- Adaptively circuit-breaking requests to a system showing signs of overload ([see the equation described here](https://sre.google/sre-book/handling-overload/#eq2101))
- Implementing a per-client retry budget as a proportion of all requests (described in the `Deciding to Retry` section later on in the same chapter).

Nothing on this branch in final; the interfaces will likely change, but I wanted to gather some initial thoughts and get feedback. My idea is to introduce a new interface: `Throttler` which signals when to skip a request. By default, the roundtripper won't use any throttling because it uses memory and cpu so it should be totally optional. A new transport instantiation option function will be created for a consumer to specify a throttler. It doesn't make sense to allow setting a throttler on the context though, so that won't be an option (although maybe there should be a context key to bypass a previously-specified throttler on a per-request basis).

My draft default throttler tracks 3 counts over a sliding time window: total requests, number of requests that came back with an "overloaded" response, and the number of retries. Keeping a sum over a sliding window is a little bit tricky. Since every request goes through the throttler, I wanted to avoid memory allocation and mutex contention. My draft solution is the `atomicCounter` type in `counter.go`. It breaks the time window into `n` buckets. Increments just perform an atomic increment on the currently active bucket, and "reading" the current count just sums over each bucket, performing an atomic load on each entry. The last piece is a `time.Ticker` which periodically atomically zeroes out the oldest bucket, then atomically moves the index to the new bucket. This trades granularity for performance, which I think is the right choice here.