### PR TITLE
feature: wrap returned error when retries exhausted

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.16'
+        go-version: '1.20'
 
     - name: Test
       run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/justinrixx/retryhttp
 
-go 1.16
+go 1.20

--- a/options.go
+++ b/options.go
@@ -12,7 +12,6 @@ type (
 	delayFnContextKeyType              string
 	preventRetryWithBodyContextKeyType string
 	attemptTimeoutContextKeyType       string
-	wrapErrorContextKeyType            string
 )
 
 const (
@@ -21,7 +20,6 @@ const (
 	delayFnContextKey              = delayFnContextKeyType("delayFn")
 	preventRetryWithBodyContextKey = preventRetryWithBodyContextKeyType("preventRetryWithBody")
 	attemptTimeoutContextKey       = attemptTimeoutContextKeyType("attemptTimeout")
-	wrapErrorContextKey            = wrapErrorContextKeyType("wrapError")
 )
 
 // WithTransport configures a Transport with an internal roundtripper of its own.
@@ -77,16 +75,6 @@ func WithAttemptTimeout(attemptTimeout time.Duration) func(*Transport) {
 	}
 }
 
-// WithWrapError configures whether to wrap errors with additional context when retries
-// are exhausted. When enabled, the final error will be wrapped with [ErrRetriesExhausted]
-// to make it clear that the failure was due to retry exhaustion rather than a single
-// request failure. This can be helpful for debugging and monitoring.
-func WithWrapError(wrapError bool) func(*Transport) {
-	return func(t *Transport) {
-		t.wrapError = wrapError
-	}
-}
-
 // SetMaxRetries can be used to override the settings on a Transport.
 // Any request made with the returned context will have its MaxRetries setting
 // overridden with the provided value.
@@ -122,13 +110,6 @@ func SetAttemptTimeout(ctx context.Context, attemptTimeout time.Duration) contex
 	return context.WithValue(ctx, attemptTimeoutContextKey, attemptTimeout)
 }
 
-// SetWrapError can be used to override the settings on a Transport.
-// Any request made with the returned context will have its WrapError setting
-// overridden with the provided value.
-func SetWrapError(ctx context.Context, wrapError bool) context.Context {
-    return context.WithValue(ctx, wrapErrorContextKey, wrapError)
-}
-
 func getMaxRetriesFromContext(ctx context.Context) (int, bool) {
 	val, ok := ctx.Value(maxRetriesContextKey).(int)
 	return val, ok
@@ -152,9 +133,4 @@ func getPreventRetryWithBodyFromContext(ctx context.Context) (bool, bool) {
 func getAttemptTimeoutFromContext(ctx context.Context) (time.Duration, bool) {
 	val, ok := ctx.Value(attemptTimeoutContextKey).(time.Duration)
 	return val, ok
-}
-
-func getWrapErrorFromContext(ctx context.Context) (bool, bool) {
-    val, ok := ctx.Value(wrapErrorContextKey).(bool)
-    return val, ok
 }

--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ type (
 	delayFnContextKeyType              string
 	preventRetryWithBodyContextKeyType string
 	attemptTimeoutContextKeyType       string
+	wrapErrorContextKeyType            string
 )
 
 const (
@@ -20,6 +21,7 @@ const (
 	delayFnContextKey              = delayFnContextKeyType("delayFn")
 	preventRetryWithBodyContextKey = preventRetryWithBodyContextKeyType("preventRetryWithBody")
 	attemptTimeoutContextKey       = attemptTimeoutContextKeyType("attemptTimeout")
+	wrapErrorContextKey            = wrapErrorContextKeyType("wrapError")
 )
 
 // WithTransport configures a Transport with an internal roundtripper of its own.
@@ -75,6 +77,16 @@ func WithAttemptTimeout(attemptTimeout time.Duration) func(*Transport) {
 	}
 }
 
+// WithWrapError configures whether to wrap errors with additional context when retries
+// are exhausted. When enabled, the final error will be wrapped with [ErrRetriesExhausted]
+// to make it clear that the failure was due to retry exhaustion rather than a single
+// request failure. This can be helpful for debugging and monitoring.
+func WithWrapError(wrapError bool) func(*Transport) {
+	return func(t *Transport) {
+		t.wrapError = wrapError
+	}
+}
+
 // SetMaxRetries can be used to override the settings on a Transport.
 // Any request made with the returned context will have its MaxRetries setting
 // overridden with the provided value.
@@ -110,6 +122,13 @@ func SetAttemptTimeout(ctx context.Context, attemptTimeout time.Duration) contex
 	return context.WithValue(ctx, attemptTimeoutContextKey, attemptTimeout)
 }
 
+// SetWrapError can be used to override the settings on a Transport.
+// Any request made with the returned context will have its WrapError setting
+// overridden with the provided value.
+func SetWrapError(ctx context.Context, wrapError bool) context.Context {
+    return context.WithValue(ctx, wrapErrorContextKey, wrapError)
+}
+
 func getMaxRetriesFromContext(ctx context.Context) (int, bool) {
 	val, ok := ctx.Value(maxRetriesContextKey).(int)
 	return val, ok
@@ -133,4 +152,9 @@ func getPreventRetryWithBodyFromContext(ctx context.Context) (bool, bool) {
 func getAttemptTimeoutFromContext(ctx context.Context) (time.Duration, bool) {
 	val, ok := ctx.Value(attemptTimeoutContextKey).(time.Duration)
 	return val, ok
+}
+
+func getWrapErrorFromContext(ctx context.Context) (bool, bool) {
+    val, ok := ctx.Value(wrapErrorContextKey).(bool)
+    return val, ok
 }

--- a/transport.go
+++ b/transport.go
@@ -30,8 +30,8 @@ var (
 	ErrSeekingBody = errors.New("error seeking body buffer back to beginning after attempt")
 
 	// ErrRetriesExhausted is a sentinel that signals all retry attempts have been exhausted.
-	// When WithWrapError is enabled, this error will wrap the last attempt's error to provide
-	// clearer context about why the request failed. A caller can identify this case using
+	// This error will be joined with the last attempt's error to prvide clearer context
+	// about why the request failed. A caller can identify this case using
 	// errors.Is(err, ErrRetriesExhausted).
 	ErrRetriesExhausted = errors.New("max retries exhausted")
 )

--- a/transport.go
+++ b/transport.go
@@ -30,7 +30,7 @@ var (
 	ErrSeekingBody = errors.New("error seeking body buffer back to beginning after attempt")
 
 	// ErrRetriesExhausted is a sentinel that signals all retry attempts have been exhausted.
-	// This error will be joined with the last attempt's error to prvide clearer context
+	// This error will be joined with the last attempt's error to provide clearer context
 	// about why the request failed. A caller can identify this case using
 	// errors.Is(err, ErrRetriesExhausted).
 	ErrRetriesExhausted = errors.New("max retries exhausted")

--- a/transport_test.go
+++ b/transport_test.go
@@ -3,6 +3,7 @@ package retryhttp_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-	"errors"
 
 	"github.com/justinrixx/retryhttp"
 )
@@ -341,120 +341,52 @@ func TestTransport_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestWrapError(t *testing.T) {
-    // Create a server that closes connections to trigger errors
-    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        // Close connection immediately to trigger EOF
-        hj, ok := w.(http.Hijacker)
-        if !ok {
-            t.Fatal("server doesn't support hijacking")
-        }
-        conn, _, err := hj.Hijack()
-        if err != nil {
-            t.Fatal(err)
-        }
-        conn.Close()
-    }))
-    defer ts.Close()
+func TestRetriesExhaustedError(t *testing.T) {
+	// Create a server that closes connections to trigger errors
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close connection immediately to trigger EOF
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server doesn't support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatal(err)
+		}
+		conn.Close()
+	}))
+	defer ts.Close()
 
-    t.Run("with wrap error enabled", func(t *testing.T) {
-        tr := retryhttp.New(
-            retryhttp.WithMaxRetries(2),
-            retryhttp.WithWrapError(true),
-            retryhttp.WithDelayFn(func(_ retryhttp.Attempt) time.Duration {
-                return 0
-            }),
-            retryhttp.WithShouldRetryFn(func(attempt retryhttp.Attempt) bool {
-                return attempt.Err != nil // Ensures EOF errors are retried
-            }),
-        )
+	t.Run("with wrap error enabled", func(t *testing.T) {
+		tr := retryhttp.New(
+			retryhttp.WithMaxRetries(2),
+			retryhttp.WithDelayFn(func(_ retryhttp.Attempt) time.Duration {
+				return 0
+			}),
+			retryhttp.WithShouldRetryFn(func(attempt retryhttp.Attempt) bool {
+				return attempt.Err != nil // Ensures EOF errors are retried
+			}),
+		)
 
-        client := http.Client{
-            Transport: tr,
-        }
+		client := http.Client{
+			Transport: tr,
+		}
 
-        req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-        if err != nil {
-            t.Fatalf("error creating request: %s", err)
-        }
+		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+		if err != nil {
+			t.Fatalf("error creating request: %s", err)
+		}
 
-        _, err = client.Do(req)
-        if err == nil {
-            t.Fatal("expected error but got nil")
-        }
+		_, err = client.Do(req)
+		if err == nil {
+			t.Fatal("expected error but got nil")
+		}
 
-        // Check that the error is wrapped with ErrRetriesExhausted
-        if !errors.Is(err, retryhttp.ErrRetriesExhausted) {
-            t.Errorf("expected error to be wrapped with ErrRetriesExhausted, got: %v", err)
-        }
-    })
-    
-    t.Run("with wrap error disabled", func(t *testing.T) {
-        tr := retryhttp.New(
-            retryhttp.WithMaxRetries(2),
-            retryhttp.WithWrapError(false),
-            retryhttp.WithDelayFn(func(_ retryhttp.Attempt) time.Duration {
-                return 0
-            }),
-            retryhttp.WithShouldRetryFn(func(attempt retryhttp.Attempt) bool {
-                return attempt.Err != nil // Retry all errors
-            }),
-        )
-
-        client := http.Client{
-            Transport: tr,
-        }
-
-        req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-        if err != nil {
-            t.Fatalf("error creating request: %s", err)
-        }
-
-        _, err = client.Do(req)
-        if err == nil {
-            t.Fatal("expected error but got nil")
-        }
-
-        // Check that the error is NOT wrapped with ErrRetriesExhausted
-        if errors.Is(err, retryhttp.ErrRetriesExhausted) {
-            t.Errorf("expected error to not be wrapped with ErrRetriesExhausted, got: %v", err)
-        }
-    })
-
-	t.Run("context override to enable wrap error", func(t *testing.T) {
-        tr := retryhttp.New(
-            retryhttp.WithMaxRetries(2),
-            retryhttp.WithWrapError(false), // Transport says don't wrap
-            retryhttp.WithDelayFn(func(_ retryhttp.Attempt) time.Duration {
-                return 0
-            }),
-            retryhttp.WithShouldRetryFn(func(attempt retryhttp.Attempt) bool {
-                return attempt.Err != nil
-            }),
-        )
-
-        client := http.Client{
-            Transport: tr,
-        }
-
-        req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-        if err != nil {
-            t.Fatalf("error creating request: %s", err)
-        }
-
-        // Context overrides to enable wrapping
-        ctx := retryhttp.SetWrapError(context.Background(), true)
-        
-        _, err = client.Do(req.WithContext(ctx))
-        if err == nil {
-            t.Fatal("expected error but got nil")
-        }
-
-        // Check that the error IS wrapped because context overrode it
-        if !errors.Is(err, retryhttp.ErrRetriesExhausted) {
-            t.Errorf("expected error to be wrapped with ErrRetriesExhausted due to context override, got: %v", err)
-        }
-    })
+		// Check that the error is wrapped with ErrRetriesExhausted
+		if !errors.Is(err, retryhttp.ErrRetriesExhausted) {
+			t.Errorf("expected error to be wrapped with ErrRetriesExhausted, got: %v", err)
+		}
+	})
 }
 
 func TestPerAttemptTimeout(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR adds a new `WithWrapError` option that allows errors to be wrapped with `ErrRetriesExhausted` when all retry attempts have been exhausted. This provides better context for debugging and monitoring by making it clear when failures are due to retry exhaustion rather than a single request failure.

## Motivation

Currently, when retries are exhausted, the library returns the last attempt's error directly. This makes it difficult to distinguish between:
- A single request that failed (no retries attempted)
- A request that failed after exhausting all retries

## Changes

- Added `ErrRetriesExhausted` sentinel error that can be checked with `errors.Is()`
- Added `WithWrapError(bool)` option to enable error wrapping
- Added `SetWrapError(ctx, bool)` for per-request override via context
- Error wrapping only occurs when:
  - Retries are exhausted
  - An actual error occurred (not just status codes)
  - The feature is explicitly enabled

## Usage Example
```go
// Enable error wrapping at transport level
transport := retryhttp.New(
    retryhttp.WithMaxRetries(3),
    retryhttp.WithWrapError(true),
)

client := &http.Client{Transport: transport}
resp, err := client.Get("https://example.com")

if errors.Is(err, retryhttp.ErrRetriesExhausted) {
    // Handle retry exhaustion specifically
    log.Error("Request failed after exhausting all retries", err)
}