### PR TITLE
Wrong error wrapped when seeking fails

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -206,7 +206,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		delay := delayFn(attempt)
 		if br != nil {
 			if _, serr := br.Seek(0, 0); serr != nil {
-				return injectCancelReader(res, cancel), fmt.Errorf("%w: %s", ErrSeekingBody, err)
+				return injectCancelReader(res, cancel), fmt.Errorf("%w: %s", ErrSeekingBody, serr)
 			}
 			reqWithTimeout.Body = io.NopCloser(br)
 		}


### PR DESCRIPTION
Evaluating this package I saw that seek errors aren't properly wrapped. Here's a fix.